### PR TITLE
Updated Manifest to reference the Lib assets as they could not be found online

### DIFF
--- a/CountdownWidget/CountdownWidget/vss-extension.json
+++ b/CountdownWidget/CountdownWidget/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "CountdownWidget",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "DevMikaelKrief",
   "name": "Countdown Widgets",
   "description": "Count down to a configurable moment in time, or down to the end of the current sprint.",
@@ -132,6 +132,10 @@
     {
       "addressable": true,
       "path": "static/img"
+    },
+    {
+      "addressable": true,
+      "path": "static/lib"
     },
     {
       "path": "dist",


### PR DESCRIPTION
Updated the manifest to include the Lib assets as they could not be found. Tested on my own sandbox environment.

See screenshot for test results
![image](https://user-images.githubusercontent.com/811869/29564435-0a57dd2c-8742-11e7-829b-ca63db2af962.png)
