### PR TITLE
Change day value displayed to nearest 10th of a day, float value

### DIFF
--- a/CountdownWidget/CountdownWidget/src/countdownCalculator.ts
+++ b/CountdownWidget/CountdownWidget/src/countdownCalculator.ts
@@ -34,7 +34,7 @@ export class CountdownCalculator {
 		}
 
 		const diff = (unit: countdownResult.Unit) => {
-			return this.to.diff(this.from, countdownResult.Unit[unit].toLowerCase(), false);
+			return this.to.diff(this.from, countdownResult.Unit[unit].toLowerCase(), unit === countdownResult.Unit.Days);
 		};
 
 		let numberOfExcludedDays = 0;
@@ -44,13 +44,12 @@ export class CountdownCalculator {
 
 		const test = diff(countdownResult.Unit.Days);
 		this.to.add(-numberOfExcludedDays, countdownResult.Unit[countdownResult.Unit.Days].toLowerCase());
-		const numberOfDays = diff(countdownResult.Unit.Days);
+		const numberOfDays:number = diff(countdownResult.Unit.Days);
 
-		if (numberOfDays >= 1) {
-			return new countdownResult.CountdownResult(numberOfDays, countdownResult.Unit.Days);
+		if (numberOfDays >= 1.0) {
+			return new countdownResult.CountdownResult(numberOfDays, countdownResult.Unit.Days); // round up to the nearest 10th of a day and remove extranneous fractional part
 		} else {
 			const numberOfHours = diff(countdownResult.Unit.Hours);
-
 			if (numberOfHours >= 1) {
 				return new countdownResult.CountdownResult(numberOfHours, countdownResult.Unit.Hours);
 			} else {

--- a/CountdownWidget/CountdownWidget/src/countdownWidget.ts
+++ b/CountdownWidget/CountdownWidget/src/countdownWidget.ts
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 import CountdownCalculator = require("./countdownCalculator");
+import CountdownResult = require("./countdownResult");
 import moment = require("moment-timezone");
 import Work_Client = require("TFS/Work/RestClient");
 import Work_Contracts = require("TFS/Work/Contracts");
@@ -130,7 +131,12 @@ export class CountdownWiget {
 
 		if (calculator.isValid()) {
 			const result = calculator.getDifference();
-			$container.text(result.value);
+			if (result.unit === CountdownResult.Unit.Days) {
+				// round to the nearest 10th of a day, and remove extra fractional part
+				$container.text(result.value.toFixed(1));
+			} else {
+				$container.text(result.value);
+			}
 			$countdownBottomContainer.text(result.getDisplayString() + " remaining");
 		} else {
 			$container.text(0);

--- a/CountdownWidget/CountdownWidget/tests/CountdownCalculatorSpec.ts
+++ b/CountdownWidget/CountdownWidget/tests/CountdownCalculatorSpec.ts
@@ -108,7 +108,8 @@ describe("countdown ", () => {
 				moment.tz("11-10-2016 23:59", "DD-MM-YYYY H:m", "Europe/Paris"), DayOfWeeks);
 
 			const countdownResult = calculator.getDifference();
-			expect(countdownResult.value).toBe(3);
+			expect(countdownResult.value).toBeGreaterThan(3.4);
+			expect(countdownResult.value).toBeLessThan(3.5);
 			expect(CountdownResult.Unit[countdownResult.unit]).toBe("Days");
 		});
 	it(
@@ -121,12 +122,13 @@ describe("countdown ", () => {
 				moment.tz("11-10-2016 23:59", "DD-MM-YYYY H:m", "Europe/Paris"), DayOfWeeks);
 
 			const countdownResult = calculator.getDifference();
-			expect(countdownResult.value).toBe(3);
+			expect(countdownResult.value).toBeGreaterThan(3.4);
+			expect(countdownResult.value).toBeLessThan(3.5);
 			expect(CountdownResult.Unit[countdownResult.unit]).toBe("Days");
 		});
 	it(
 		`use case 3 : diff from 16-10-2016 11:38 Europe/Paris to 30-10-2016 23:59 Europe/Paris
-			With skip no-working days to be 19 days`,
+			With skip no-working days to be 14.5 days`,
 		() => {
 			const DayOfWeeks = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
 
@@ -135,7 +137,7 @@ describe("countdown ", () => {
 				moment.tz("30-10-2016 23:59", "DD-MM-YYYY H:m", "Europe/Paris"), DayOfWeeks);
 
 			const countdownResultWithSkip = calculatorWithSkip.getDifference();
-			expect(countdownResultWithSkip.value).toBe(14);
+			expect(countdownResultWithSkip.value.toFixed(1)).toBe("14.5");
 		});
 	it(
 		`use case 3 bis: diff from 13-10-2016 11:38 Europe/Paris to 30-10-2016 23:59 Europe/Paris
@@ -148,7 +150,7 @@ describe("countdown ", () => {
 				moment.tz("30-10-2016 23:59", "DD-MM-YYYY H:m", "Europe/Paris"), DayOfWeeks);
 
 			const countdownResultWithSkip = calculatorWithSkip.getDifference();
-			expect(countdownResultWithSkip.value).toBe(11);
+			expect(countdownResultWithSkip.value.toFixed(1)).toBe("11.5");
 		});
 	it(
 		`use case 4 : diff from 16-10-2016 11:38 Europe/Paris to 30-10-2016 23:59 Europe/Paris
@@ -161,7 +163,7 @@ describe("countdown ", () => {
 				moment.tz("30-10-2016 23:59", "DD-MM-YYYY H:m", "Europe/Paris"));
 
 			const countdownResultNoSkip = calculatorNoSkip.getDifference();
-			expect(countdownResultNoSkip.value).toBe(14);
+			expect(countdownResultNoSkip.value.toFixed(1)).toBe("14.5");
 		});
 	it(
 		`use case 5: diff from 23-10-2016 11:38 Europe/Paris to 30-10-2016 23:59 Europe/Paris
@@ -173,7 +175,7 @@ describe("countdown ", () => {
 				moment.tz("30-10-2016 23:59", "DD-MM-YYYY H:m", "Europe/Paris"), DayOfWeeks);
 
 			const countdownResult = calculator.getDifference();
-			expect(countdownResult.value).toBe(7);
+			expect(countdownResult.value.toFixed(1)).toBe("7.5");
 			expect(CountdownResult.Unit[countdownResult.unit]).toBe("Days");
 		});
 });

--- a/CountdownWidget/CountdownWidget/vss-extension.json
+++ b/CountdownWidget/CountdownWidget/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "CountdownWidget",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publisher": "DevMikaelKrief",
   "name": "Countdown Widgets",
   "description": "Count down to a configurable moment in time, or down to the end of the current sprint.",


### PR DESCRIPTION
Fixes #20.
Changes proposed in this pull request:  
- Calculation of days becomes floating-point (only days, everything else such as hours, minutes remains the same)
- Update to tests to use the 'toFixed' method
- Update rendering on the countdown widget for days only

Will need help testing!

@ALM-Rangers/countdownwidget
